### PR TITLE
ngrok support

### DIFF
--- a/launchpad/job/nni_job.py
+++ b/launchpad/job/nni_job.py
@@ -1,7 +1,6 @@
 import os
 import yaml
 import sys
-import json
 import shutil
 import time
 import socket
@@ -10,14 +9,11 @@ import uuid
 import json
 import getpass
 import traceback
-import shlex
+from pyngrok import ngrok
 from psutil import process_iter
-from subprocess import (PIPE,
-                        Popen,
-                        check_call, 
+from subprocess import (check_call, 
                         check_output,
                         CalledProcessError)
-from pyngrok import ngrok
 
 from .base import BaseJob
 from .slurm_job import SlurmJob

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fire>=0.2
 scikit-learn>=0.20
 importlib-resources==1.4.0
+pyngrok>=5.0.1
+psutil>=5.8.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ INSTALL_REQUIRES = (
      'pandas',
      'tabulate',
      'pyyaml',
-     'cachetools'
+     'cachetools',
+     'pyngrok'
      ]
 )
 

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,13 @@ INSTALL_REQUIRES = (
     ['fire>=0.2',
      'scikit-learn>=0.20',
      'importlib-resources==1.4.0',
+     'pyngrok>=5.0.1',
+     'psutil>=5.8.0',
      'numpy',
      'pandas',
      'tabulate',
      'pyyaml',
-     'cachetools',
-     'pyngrok'
+     'cachetools'
      ]
 )
 


### PR DESCRIPTION
### New Feature
 - Added support for tunneling NNI UI to ngrok server to run on workbench machines

### Test
Add `tunnel: ngrok `under `meta` in the config file and run:
test config: [config_nni.yaml.zip](https://github.com/stanfordmlgroup/LaunchPad/files/5852451/config_nni.yaml.zip)
```
lp config_nni.yaml --run shell
```