### PR TITLE
Add account to sbatch script

### DIFF
--- a/launchpad/job/scripts/sbatch_template.sh
+++ b/launchpad/job/scripts/sbatch_template.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#SBATCH --account=deep
 #SBATCH --partition=deep --qos=normal
 #SBATCH --nodes=1
 #SBATCH --cpus-per-task=4


### PR DESCRIPTION
SC cluster upgrade requires the --account flag for sbatch now; add it to the template script. 