### PR TITLE
Add support for transferring files before training

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ Please refer to [online sbatch documentation via SchedMD](https://slurm.schedmd.
 ### Experiment parameters
 `hp` section is fully customized by user. They are hyper-parameters we want to scan for the training experiments. 
 
+### Data parameters
+`data` section is optional and can be used to transfer data files (ie, hdf5 dataset) to a machine.
+This is useful for preventing excessive reads from `/deep`.
+- `src_paths`: list of paths that we want to transfer (ie, hdf5 dataset(s))
+- `dst_dir`: path where we want to transfer `src_paths` (ie, `/scr`). `dst_dir` will be removed upon script completion.
+
 ### NNI parameters
 `nni` section is optional and only effective when `run == "nni"`. A detailed description can be found [here](https://nni.readthedocs.io/en/latest/Tutorial/ExperimentConfig.html).
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ Please refer to [online sbatch documentation via SchedMD](https://slurm.schedmd.
 ### Data parameters
 `data` section is optional and can be used to transfer data files (ie, hdf5 dataset) to a machine.
 This is useful for preventing excessive reads from `/deep`.
-- `src_paths`: list of paths that we want to transfer (ie, hdf5 dataset(s))
-- `dst_dir`: path where we want to transfer `src_paths` (ie, `/scr`). `dst_dir` will be removed upon script completion.
+- `src_path`: path for file that we want to transfer (ie, HDF5 dataset)
+- `dst_dir`: directory where we want to transfer `src_path` (`/scr/*`). 
+  `dst_dir` will be removed upon script completion.
+  NOTE: `dst_dir` MUST be a subdirectory of `scr` (local storage), or args will be ignored.
 
 ### NNI parameters
 `nni` section is optional and only effective when `run == "nni"`. A detailed description can be found [here](https://nni.readthedocs.io/en/latest/Tutorial/ExperimentConfig.html).

--- a/launchpad/job/master_job.py
+++ b/launchpad/job/master_job.py
@@ -61,7 +61,7 @@ class MasterJob(BaseJob):
     def print_state(self, idx, job):
         state = job.get_state()
         print("-" * self._col)
-        print(f"Experiment No.{idx+1} -- [{job._exp_name}]:\n{job._exec_line}")
+        print(f"Experiment No.{idx+1} -- [{job._exp_name}]:\n{job._exec_line_display}")
         print(f"Current State: {colorful_state(state)}") 
         if state == "Running":
             print(f"Slurm job ID: {job._id}")

--- a/launchpad/job/shell_job.py
+++ b/launchpad/job/shell_job.py
@@ -20,7 +20,7 @@ class ShellJob(BaseJob):
 
     def run(self): 
         try:
-            check_call(self._exec_line.split())
+            check_call(self._exec_line, shell=True)
             self.state = "Finished"
         except CalledProcessError as e:
             self.state = "Failed"

--- a/launchpad/util/config.py
+++ b/launchpad/util/config.py
@@ -1,6 +1,7 @@
 import yaml
 import os
 import copy
+from pathlib import Path
 from sklearn.model_selection import ParameterGrid, ParameterSampler
 
 
@@ -56,10 +57,23 @@ class Config:
         else:
             self.nni = None
             
+        self.src_path = None 
+        self.dst_dir = None
         if 'data' in _config:
-            self.data = Args(_config['data'])            
-        else:
-            self.data = None
+            data = Args(_config['data'])
+            if 'src_path' in data:
+                if Path(data['src_path']).exists():
+                    self.src_path = data['src_path']
+                else:
+                    print(f"Ignoring src_path - does not exist: [{data['src_path']}].")
+            if 'dst_dir' in data:
+                if (Path(data['dst_dir']).is_relative_to("/scr") and 
+                    Path(data['dst_dir']).name != "scr"):
+                    self.dst_dir = data['dst_dir']
+                    if not self.dst_dir.endswith("/"):
+                        self.dst_dir += "/"
+                else:
+                    print(f"Ignoring dst_dir - is not a subdirectory of /scr: [{data['dst_dir']}].")
     
     def __iter__(self):
         self.round = 0

--- a/launchpad/util/config.py
+++ b/launchpad/util/config.py
@@ -55,6 +55,11 @@ class Config:
             self.nni = Args(_config['nni'])
         else:
             self.nni = None
+            
+        if 'data' in _config:
+            self.data = Args(_config['data'])            
+        else:
+            self.data = None
     
     def __iter__(self):
         self.round = 0


### PR DESCRIPTION
Adds an optional `data` key to the config, where values are:
- `src_paths` (list of path strs): files we want to tranfer 
- `dst_dir` (path str): destination directory for files

If these values are provided, we `rysnc` `src_paths` to `dst_dir` before the execution line, and `rm -rf dst_dir` after the execution line. 

The primary use case for the `data` config key is specifying an hdf5 dataset (`src_path`) to be transferred to `/scr` (`dst_dir`), so we can train models without excessive reads from `/deep`. 

Verified that the functionality works with a test config for shell, sbatch, and nni. 