### PR TITLE
Add an option to handle hydra argument format

### DIFF
--- a/launchpad/job/base.py
+++ b/launchpad/job/base.py
@@ -70,7 +70,7 @@ class BaseJob:
         executor, script_path, args = self._parse_script()
         self._code_dir = os.path.dirname(script_path)
         self._exec_line = " ".join([executor, script_path] + args \
-                + [f"--{k} {v}" for k, v in self._hp.items()])
+                        + [f"model.optimizer.lr={v}" if k == 'lr' else f"{k}={v}" for k, v in self._hp.items() if k != 'round' and k != 'exp_name'])
         self._exec_line_display = self._exec_line
         
     def _get_exp_name(self): 

--- a/launchpad/job/base.py
+++ b/launchpad/job/base.py
@@ -69,8 +69,12 @@ class BaseJob:
     def _get_exec_line(self):
         executor, script_path, args = self._parse_script()
         self._code_dir = os.path.dirname(script_path)
-        self._exec_line = " ".join([executor, script_path] + args \
+        if self._meta.hydra:
+            self._exec_line = " ".join([executor, script_path] + args \
                         + [f"model.optimizer.lr={v}" if k == 'lr' else f"{k}={v}" for k, v in self._hp.items() if k != 'round' and k != 'exp_name'])
+        else:
+            self._exec_line = " ".join([executor, script_path] + args \
+                + [f"--{k} {v}" for k, v in self._hp.items()])
         self._exec_line_display = self._exec_line
         
     def _get_exp_name(self): 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def version():
 
 
 setup(
-    name='launch-pad-test',
+    name='launch-pad-sai',
     version=version(),
     description='A tool that automatically compile and launch slurm jobs \
                  based on a YAML configuration file.',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def version():
 
 
 setup(
-    name='launch-pad',
+    name='launch-pad-test',
     version=version(),
     description='A tool that automatically compile and launch slurm jobs \
                  based on a YAML configuration file.',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def version():
 
 
 setup(
-    name='launch-pad-sai',
+    name='launch-pad',
     version=version(),
     description='A tool that automatically compile and launch slurm jobs \
                  based on a YAML configuration file.',


### PR DESCRIPTION
## Problem
Previously, the CLI list assumed the script expects argparse formatted arguments. 

## Solution
Added an option to handle hydra formatted arguments. This option is specified so it can be used for the SAI project (`lr` becomes `model.optimizer.lr`). 

## Testing
Tested by installing the package from the fork and ran these commands:
`lp config.yaml` and `lp config.yaml --run slurm`.